### PR TITLE
Prepare kie-serializer-maven-plugin for addition to a public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# maven-kie-serializer-plugin
+# kie-serializer-maven-plugin
 Kie serializer for Maven that really works
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# kie-serializer-maven-plugin
+# maven-kie-serializer-plugin
 Kie serializer for Maven that really works
+
+## Example
+
+```xml
+<plugin>
+  <groupId>com.savi.maven.plugins</groupId>
+  <artifactId>kie-serializer-maven-plugin</artifactId>
+  <version>1.0.0</version>
+  <extensions>true</extensions>
+  <configuration>
+    <!-- resDirectory is where the resulting serialized file lands -->
+    <resDirectory>${project.basedir}/target/classes</resDirectory>
+    <!-- The KieBase to serialize, as configured in kmodule.xml -->
+    <kiebases>ShipmentKBase</kiebases>
+  </configuration>
+  <executions>
+    <execution>
+      <phase>compile</phase>
+      <goals>
+        <goal>serialize</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,58 @@
   <groupId>com.savi.maven.plugins</groupId>
   <artifactId>kie-serializer-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0-SNAPSHOT</version>
-  <name>kie-serializer-plugin Maven Mojo</name>
-  <url>http://maven.apache.org</url>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Serializes compiled KieBases to the JAR
+      for fast consumption</description>
+  <url>https://github.com/sensoranalytics/kie-serializer-maven-plugin</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>James Nowell</name>
+      <email>jnowell@savi.com</email>
+      <organization>Savi Technology</organization>
+      <organizationUrl>http://www.savi.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/sensoranalytics/kie-serializer-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://github.com/sensoranalytics/kie-serializer-maven-plugin.git</developerConnection>
+    <url>https://github.com/sensoranalytics/kie-serializer-maven-plugin</url>
+  </scm>
+
   <properties>
     <drools.version>6.3.0.Final</drools.version>
   </properties>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -48,6 +91,56 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.savi.maven.plugins</groupId>
   <artifactId>kie-serializer-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Serializes compiled KieBases to the JAR
       for fast consumption</description>

--- a/src/main/java/com/savi/maven/plugins/IncludeProjectDependenciesComponentConfigurator.java
+++ b/src/main/java/com/savi/maven/plugins/IncludeProjectDependenciesComponentConfigurator.java
@@ -11,8 +11,6 @@ import org.codehaus.plexus.component.configurator.converters.special.ClassRealmC
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -26,8 +24,6 @@ import java.util.List;
  */
 @Component(role=ComponentConfigurator.class, hint="include-project-dependencies")
 public class IncludeProjectDependenciesComponentConfigurator extends AbstractComponentConfigurator {
-
-    private static final Logger LOGGER = new ConsoleLogger(Logger.LEVEL_DEBUG, "Configurator");
 
     public void configureComponent( Object component, PlexusConfiguration configuration,
                                     ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm,
@@ -67,9 +63,6 @@ public class IncludeProjectDependenciesComponentConfigurator extends AbstractCom
             try {
                 final URL url = new File(element).toURI().toURL();
                 urls.add(url);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Added to project class loader: " + url);
-                }
             } catch (MalformedURLException e) {
                 throw new ComponentConfigurationException("Unable to access project dependency: " + element, e);
             }


### PR DESCRIPTION
@dsbos @JimHaughwout (I'd tag Luke and Matt, but it seems like they aren't in the group?)

I took a little time to start getting one of our OS projects ready to go to Maven Central. I've been following a few guides:

1. [The overall guide](http://central.sonatype.org/pages/ossrh-guide.html#deploymentl)
2. [The requirements guide](http://central.sonatype.org/pages/requirements.html)
3. [The Maven specific guide](http://central.sonatype.org/pages/apache-maven.html)
4. [Finally, this guide for pushbutton releases](http://www.sonatype.org/nexus/2015/01/08/deploy-to-maven-central-repository/)

The next step is going to be issuing a ticket to Sonatype to create the new project in Nexus so we can test some snapshots. I wanted to make sure the repo looks reasonably ready to go before the ticket gets created.

Once they create the project, we can make a couple of snapshots to test that it's working (for example, by cleaning the M2 repository for some build on Jenkins and removing the plugin build step), then we can make a 1.0.0 release and scrap a bunch of extra steps in our Jenkins builds.